### PR TITLE
lab01: AI Agent를 직접 검수 방식으로 변경 및 Streamlit base64 이미지 지원 추가

### DIFF
--- a/lab01-review-moderator/agent/review_moderator/agent.py
+++ b/lab01-review-moderator/agent/review_moderator/agent.py
@@ -89,102 +89,48 @@ def moderate_review(
     """
     
     try:
-        result = review_moderation_agent(moderation_prompt)
+        # Agent 대신 직접 수동 검수 수행
+        from .tools import check_profanity, check_rating_consistency, check_image_product_match
         
-        # Agent 응답에서 JSON 추출
-        response_text = str(result)
+        # 욕설 검사
+        profanity_result = check_profanity(review_content)
         
-        # JSON 파싱 시도 - 여러 방법으로 시도
-        try:
-            moderation_result = None
-            
-            # 방법 1: ```json 블록에서 추출
-            if "```json" in response_text:
-                json_start = response_text.find("```json") + 7
-                json_end = response_text.find("```", json_start)
-                if json_end > json_start:
-                    json_text = response_text[json_start:json_end].strip()
-                    moderation_result = json.loads(json_text)
-            
-            # 방법 2: 마지막 JSON 객체 추출
-            if not moderation_result and "{" in response_text and "}" in response_text:
-                # 가장 마지막 완전한 JSON 객체 찾기
-                json_start = response_text.rfind("{")
-                json_end = response_text.rfind("}") + 1
-                if json_end > json_start:
-                    json_text = response_text[json_start:json_end]
-                    try:
-                        moderation_result = json.loads(json_text)
-                    except json.JSONDecodeError:
-                        # 첫 번째 JSON 객체 시도
-                        json_start = response_text.find("{")
-                        json_end = response_text.find("}") + 1
-                        if json_end > json_start:
-                            json_text = response_text[json_start:json_end]
-                            moderation_result = json.loads(json_text)
-            
-            if not moderation_result:
-                raise ValueError("JSON 형태를 찾을 수 없습니다.")
-            
-        except (json.JSONDecodeError, ValueError) as e:
-            # JSON 파싱 실패 시 수동으로 검수 수행
-            print(f"Agent JSON 파싱 실패, 수동 검수 수행: {e}")
-            
-            # 수동 검수 수행
-            from .tools import check_profanity, check_rating_consistency, check_image_product_match
-            
-            try:
-                # 욕설 검사
-                profanity_result = check_profanity(review_content)
-                
-                # 별점 일치성 검사
-                consistency_result = check_rating_consistency(rating, review_content)
-                
-                # 이미지 검사 (있는 경우에만)
-                if media_files and len(media_files) > 0:
-                    image_result = check_image_product_match(media_files, product_data)
-                    checks_performed = ["profanity_check", "image_match", "rating_consistency"]
-                else:
-                    image_result = {"status": "SKIP", "reason": "업로드된 이미지가 없습니다.", "confidence": 1.0}
-                    checks_performed = ["profanity_check", "rating_consistency"]
-                
-                # 실패한 검수 항목 수집
-                failed_checks = []
-                if profanity_result["status"] == "FAIL":
-                    failed_checks.append("profanity_check")
-                if consistency_result["status"] == "FAIL":
-                    failed_checks.append("rating_consistency")
-                if image_result["status"] == "FAIL":
-                    failed_checks.append("image_match")
-                
-                overall_status = "FAIL" if failed_checks else "PASS"
-                
-                moderation_result = {
-                    "profanity_check": profanity_result,
-                    "image_match": image_result,
-                    "rating_consistency": consistency_result,
-                    "overall_status": overall_status,
-                    "failed_checks": failed_checks,
-                    "checks_performed": checks_performed,
-                    "summary": f"수동 검수 완료 - {overall_status}"
-                }
-                
-            except Exception as manual_error:
-                # 수동 검수도 실패한 경우
-                moderation_result = {
-                    "profanity_check": {"status": "FAIL", "reason": "검수 시스템 오류", "confidence": 0.0},
-                    "image_match": {"status": "SKIP", "reason": "검수 시스템 오류", "confidence": 0.0},
-                    "rating_consistency": {"status": "FAIL", "reason": "검수 시스템 오류", "confidence": 0.0},
-                    "overall_status": "FAIL",
-                    "failed_checks": ["system_error"],
-                    "checks_performed": [],
-                    "summary": f"검수 시스템 오류: {str(manual_error)}"
-                }
+        # 별점 일치성 검사
+        consistency_result = check_rating_consistency(rating, review_content)
+        
+        # 이미지 검사 (있는 경우에만)
+        if media_files and len(media_files) > 0:
+            image_result = check_image_product_match(media_files, product_data)
+            checks_performed = ["profanity_check", "image_match", "rating_consistency"]
+        else:
+            image_result = {"status": "SKIP", "reason": "업로드된 이미지가 없습니다.", "confidence": 1.0}
+            checks_performed = ["profanity_check", "rating_consistency"]
+        
+        # 실패한 검수 항목 수집
+        failed_checks = []
+        if profanity_result["status"] == "FAIL":
+            failed_checks.append("profanity_check")
+        if consistency_result["status"] == "FAIL":
+            failed_checks.append("rating_consistency")
+        if image_result["status"] == "FAIL":
+            failed_checks.append("image_match")
+        
+        overall_status = "FAIL" if failed_checks else "PASS"
+        
+        moderation_result = {
+            "profanity_check": profanity_result,
+            "image_match": image_result,
+            "rating_consistency": consistency_result,
+            "overall_status": overall_status,
+            "failed_checks": failed_checks,
+            "checks_performed": checks_performed,
+            "summary": f"직접 검수 완료 - {overall_status}"
+        }
         
         return {
             "success": True,
             "moderation_result": moderation_result,
-            "raw_response": response_text
+            "raw_response": "직접 검수 수행"
         }
         
     except Exception as e:

--- a/lab01-review-moderator/agent/review_moderator/tools.py
+++ b/lab01-review-moderator/agent/review_moderator/tools.py
@@ -18,7 +18,7 @@ def check_profanity(content: str) -> Dict[str, Any]:
         import boto3
         import json
         
-        # Bedrock 클라이언트 초기화 (Claude 4.0 -> 3.5 사용)
+        # Bedrock 클라이언트 초기화 (Claude 3.5 사용)
         bedrock = boto3.client('bedrock-runtime', region_name='us-west-2')
         
         # Claude에게 보낼 프롬프트
@@ -46,7 +46,7 @@ def check_profanity(content: str) -> Dict[str, Any]:
 }}
 """
         
-        # Bedrock API 호출 (Claude Sonnet 4->3.5)
+        # Bedrock API 호출 (Claude 3.5 Sonnet)
         response = bedrock.invoke_model(
             modelId="anthropic.claude-3-5-sonnet-20241022-v2:0",
             body=json.dumps({
@@ -185,32 +185,41 @@ def check_image_product_match(media_files: List[Dict], product_data: Dict) -> Di
         # 첫 번째 이미지만 검사 (여러 이미지가 있을 경우)
         first_media = media_files[0]
         
-        # 이미지 파일 경로 구성
-        # URL에서 실제 파일 경로 추출
+        # 이미지 데이터 추출
         image_url = first_media.get("url", "")
-        if image_url.startswith("/uploads/media/"):
-            # agents/review_moderator/tools.py -> backend/uploads/media/
+        
+        if image_url.startswith("data:image/"):
+            # Streamlit에서 전달된 base64 데이터 처리
+            try:
+                # data:image/jpeg;base64,{base64_data} 형식에서 base64 부분만 추출
+                image_data = image_url.split(",")[1]
+            except IndexError:
+                return {
+                    "status": "FAIL",
+                    "reason": "잘못된 base64 이미지 데이터 형식입니다.",
+                    "confidence": 0.0
+                }
+        elif image_url.startswith("/uploads/media/"):
+            # 파일 시스템 경로 처리 (기존 로직 유지)
             current_file = Path(__file__).resolve()
             project_root = current_file.parent.parent.parent
             image_path = project_root / "backend" / "uploads" / "media" / image_url.split("/")[-1]
+            
+            if not image_path.exists():
+                return {
+                    "status": "FAIL",
+                    "reason": f"이미지 파일이 존재하지 않습니다: {image_path}",
+                    "confidence": 0.0
+                }
+            
+            with open(image_path, "rb") as image_file:
+                image_data = base64.b64encode(image_file.read()).decode('utf-8')
         else:
             return {
                 "status": "FAIL",
                 "reason": f"지원하지 않는 이미지 URL 형식입니다: {image_url}",
                 "confidence": 0.0
             }
-        
-        # 이미지 파일이 존재하는지 확인
-        if not image_path.exists():
-            return {
-                "status": "FAIL",
-                "reason": f"이미지 파일이 존재하지 않습니다: {image_path}",
-                "confidence": 0.0
-            }
-        
-        # 이미지를 base64로 인코딩
-        with open(image_path, "rb") as image_file:
-            image_data = base64.b64encode(image_file.read()).decode('utf-8')
         
         # Claude Vision API 호출
         prompt = f"""
@@ -233,9 +242,9 @@ def check_image_product_match(media_files: List[Dict], product_data: Dict) -> Di
 }}
 """
         
-        # Bedrock API 호출
+        # Bedrock API 호출 (Claude 3.5 Sonnet v2)
         response = bedrock.invoke_model(
-            modelId="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+            modelId="anthropic.claude-3-5-sonnet-20241022-v2:0",
             body=json.dumps({
                 "anthropic_version": "bedrock-2023-05-31",
                 "max_tokens": 1000,
@@ -398,9 +407,9 @@ def check_rating_consistency(rating: int, content: str) -> Dict[str, Any]:
 }}
 """
         
-        # Bedrock API 호출 (이미지 검수와 동일한 모델)
+        # Bedrock API 호출 (Claude 3.5 Sonnet)
         response = bedrock.invoke_model(
-            modelId="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+            modelId="anthropic.claude-3-5-sonnet-20241022-v2:0",
             body=json.dumps({
                 "anthropic_version": "bedrock-2023-05-31",
                 "max_tokens": 1000,


### PR DESCRIPTION
## 주요 변경사항

### 1. AI Agent 제거 및 직접 검수 방식 도입
- `review_moderation_agent` 호출 완전 제거
- tools 모듈의 함수들을 직접 호출하여 검수 수행
- 복잡한 JSON 파싱 로직 제거 (102줄 → 48줄)

### 2. 기술적 개선
- Claude 모델 통일: `anthropic.claude-3-5-sonnet-20241022-v2:0`
- Streamlit base64 이미지 지원 추가 (`data:image/` 형식)
- 파일 시스템과 base64 데이터 모두 지원

### 3. 효과
- 코드 복잡성 대폭 감소
- JSON 파싱 오류 가능성 제거
- 다양한 이미지 입력 형식 지원
- 시스템 안정성 향상

### 변경된 파일
- `lab01-review-moderator/agent/review_moderator/agent.py`
- `lab01-review-moderator/agent/review_moderator/tools.py