### PR TITLE
fix(lab03): Fix image path to use local images directory

### DIFF
--- a/lab03_review_moderator/streamlit_app.py
+++ b/lab03_review_moderator/streamlit_app.py
@@ -6,7 +6,7 @@ import os
 sys.path.append('.')
 
 # 이미지 경로 설정
-IMAGES_DIR = os.path.join(os.path.dirname(__file__), "..", "images")
+IMAGES_DIR = os.path.join(os.path.dirname(__file__), "images")
 
 # 검수 에이전트 import 시도
 try:


### PR DESCRIPTION
## Summary
- Fixed IMAGES_DIR path in lab03_review_moderator/streamlit_app.py
- Changed from parent directory (`"..", "images"`) to local directory (`"images"`)
- Images now load correctly from `lab03_review_moderator/images/`

## Changes
- `IMAGES_DIR = os.path.join(os.path.dirname(__file__), "..", "images")` 
- → `IMAGES_DIR = os.path.join(os.path.dirname(__file__), "images")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)